### PR TITLE
Correct `FUNCKNAME` typo in Bash blog post

### DIFF
--- a/content/post/bash/Debugging_Bash_like_a_Sire.md
+++ b/content/post/bash/Debugging_Bash_like_a_Sire.md
@@ -158,7 +158,7 @@ function log::error {
 </br>
 For the `log::error` function I've made some adjustments. It prints the log
 line, just like `log::info`, but we also loop through every item in
-`${!FUNCKNAME[@]}` as `stack_id`. The exclamation mark in front of an array
+`${!FUNCNAME[@]}` as `stack_id`. The exclamation mark in front of an array
 expansion gives us the indexes instead of the value so now we can iterate over
 both the `BASH_SOURCE` and `FUNCNAME` arrays as they should have the same length.
 We print one line for each `stack_id` and we also grab the value from a new


### PR DESCRIPTION
Hi @brujoand,

I discovered your insightful Bash blog post through this Reddit thread [^1] and wanted to express my gratitude for sharing your knowledge! It's been a valuable resource for me.

I've created this pull request to address a minor typo I noticed while reading.

[^1]: https://www.reddit.com/r/devops/comments/18p349s/i_finally_documented_a_few_tricks_for_debugging/