### PR TITLE
Add mise tooling, pre-commit hooks, and CI linting

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,34 +1,27 @@
-# Sample workflow for building and deploying a Hugo site to GitHub Pages
 name: Deploy Hugo site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["master"]
-
-  # Allows you to run this workflow manually from the Actions tab
+  pull_request:
+    branches: ["master"]
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
-# Default to bash
 defaults:
   run:
     shell: bash
 
 jobs:
-  # Build job
-  build:
+  lint:
     runs-on: ubuntu-latest
     env:
       HUGO_VERSION: 0.140.1
@@ -37,8 +30,30 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-      - name: Install Dart Sass
-        run: sudo snap install dart-sass
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files
+
+  build:
+    runs-on: ubuntu-latest
+    needs: lint
+    if: github.ref == 'refs/heads/master'
+    env:
+      HUGO_VERSION: 0.140.1
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -46,11 +61,8 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4
-      - name: Install Node.js dependencies
-        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
         env:
-          # For maximum backward compatibility with Hugo modules
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
@@ -62,13 +74,13 @@ jobs:
         with:
           path: ./public
 
-  # Deployment job
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 public
+resources/_gen/
+.hugo_build.lock

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,7 @@
+[tools]
+hugo-extended = "0.140.1"
+gitleaks = "latest"
+shellcheck = "latest"
+
+[tools."pipx:pre-commit"]
+version = "latest"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,7 @@
 [tools]
 hugo-extended = "0.140.1"
 gitleaks = "latest"
+gh = "latest"
 shellcheck = "latest"
 
 [tools."pipx:pre-commit"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        types: [markdown, toml]
+      - id: end-of-file-fixer
+        types: [markdown, toml]
+      - id: check-added-large-files
+        args: ['--maxkb=2048']
+      - id: check-merge-conflict
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.22.1
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        files: \.(sh)$
+        exclude: ^themes/
+
+  - repo: local
+    hooks:
+      - id: hugo-build-check
+        name: Hugo build check
+        language: script
+        entry: hooks/hugo-build-check.sh
+        pass_filenames: false
+        types_or: [markdown, toml]
+
+      - id: frontmatter-lint
+        name: Front matter lint
+        language: script
+        entry: hooks/frontmatter-lint.sh
+        types: [markdown]
+
+      - id: static-asset-check
+        name: Static asset reference check
+        language: script
+        entry: hooks/static-asset-check.sh
+        types: [markdown]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A Hugo static blog deployed to GitHub Pages via GitHub Actions. The theme is `m10c` (git submodule). Pushes to `master` trigger CI that lints then builds and deploys.
+
+## Setup
+
+```bash
+mise install          # installs hugo-extended 0.140.1, gitleaks, shellcheck, pre-commit
+mise x -- pre-commit install  # installs git hooks
+```
+
+## Commands
+
+- **Local preview**: `./preview.sh` (runs `hugo server --buildDrafts`)
+- **New post**: `./new_post.sh` (interactive: fzf for category/tags, prompts for title, opens `$EDITOR`)
+- **Build**: `hugo --minify`
+- **Run hooks manually**: `mise x -- pre-commit run --all-files`
+
+## Content structure
+
+Posts live in `content/post/<category>/Title.md`. Current categories: `bash`, `crafting`, `devops`, `homelab`, `productivity`.
+
+Post front matter:
+```yaml
+---
+title: "Post title"
+date: 2024-01-01T10:00:00+01:00
+tags: ["tag1", "tag2"]
+categories: ["category"]
+draft: true
+---
+```
+
+Set `draft: false` to publish. Static assets go in `static/` and are referenced without the `/static/` prefix.
+
+## Pre-commit hooks
+
+Hooks run automatically on commit and in CI (`lint` job):
+- `trailing-whitespace`, `end-of-file-fixer` — on markdown and toml
+- `check-added-large-files` — blocks files >2MB
+- `check-merge-conflict`
+- `gitleaks` — secret detection
+- `shellcheck` — lints `*.sh` files (excludes `themes/`)
+- `hooks/hugo-build-check.sh` — full Hugo build with `--renderToMemory`
+- `hooks/frontmatter-lint.sh` — validates `title`, `date`, `categories` in post front matter
+- `hooks/static-asset-check.sh` — validates `src="/"` image paths exist in `static/`
+
+## CI / branch protection
+
+The `lint` job runs on all PRs and push to master. `build` and `deploy` only run on master after lint passes.
+
+To require PRs on GitHub: Settings → Branches → Add rule for `master` → enable "Require status checks to pass" (select `lint`) and "Require a pull request before merging".
+
+## Custom styling
+
+`assets/css/_extra.scss` is the only custom CSS, loaded on top of the m10c theme.

--- a/config.toml
+++ b/config.toml
@@ -3,8 +3,6 @@ languageCode = "en-us"
 title = "Automate attention"
 author = "Anders Brujordet"
 theme = "m10c"
-PygmentsCodeFences = true
-
 [outputs]
   page = ["HTML"]
   home = ["HTML", "RSS"]
@@ -26,6 +24,8 @@ PygmentsCodeFences = true
     url = "https://www.github.com/brujoand"
 
 [markup]
+  [markup.highlight]
+    codeFences = true
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true

--- a/hooks/frontmatter-lint.sh
+++ b/hooks/frontmatter-lint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail=0
+
+for f in "$@"; do
+  [[ "$f" == content/post/*.md || "$f" == content/post/**/*.md ]] || continue
+
+  if ! grep -q '^title:' "$f"; then
+    echo "ERROR: missing 'title' in front matter: $f"
+    fail=1
+  fi
+
+  if ! grep -q '^date:' "$f"; then
+    echo "ERROR: missing 'date' in front matter: $f"
+    fail=1
+  fi
+
+  if ! grep -q '^categories:' "$f"; then
+    echo "ERROR: missing 'categories' in front matter: $f"
+    fail=1
+  fi
+done
+
+exit $fail

--- a/hooks/hugo-build-check.sh
+++ b/hooks/hugo-build-check.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HUGO=$(mise x -- which hugo 2>/dev/null || which hugo 2>/dev/null || true)
+if [[ -z "$HUGO" ]]; then
+  echo "ERROR: hugo not found (run: mise install)"
+  exit 1
+fi
+
+"$HUGO" --renderToMemory --quiet 2>&1 || {
+  echo "ERROR: Hugo build failed"
+  exit 1
+}

--- a/hooks/static-asset-check.sh
+++ b/hooks/static-asset-check.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail=0
+
+for f in "$@"; do
+  [[ "$f" == content/* ]] || continue
+
+  while IFS= read -r src; do
+    local_path="static/${src#/}"
+    if [[ ! -f "$local_path" ]]; then
+      echo "ERROR: missing static asset '$src' referenced in $f"
+      fail=1
+    fi
+  done < <(grep -oP '(?<=src="/)[^"]+' "$f" 2>/dev/null || true)
+done
+
+exit $fail

--- a/new_post.sh
+++ b/new_post.sh
@@ -12,7 +12,7 @@ category=$(get_current_categories | fzf --bind enter:accept-non-empty)
 [[ -z "$category" ]] && exit 1
 tags_list=("$(get_current_tags | fzf -m --bind enter:accept-non-empty)")
 tags=$(printf '"%s", ' "${tags_list[@]}")
-[[ "${#tags[@]}" -eq 0 ]] && exit 1
+[[ -z "$tags" ]] && exit 1
 
 read -r -p "Enter title: " title
 

--- a/preview.sh
+++ b/preview.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-hugo -t m10c server
+hugo server --buildDrafts


### PR DESCRIPTION
## Summary

- Adds `.mise.toml` pinning `hugo-extended 0.140.1`, `gitleaks`, `shellcheck`, `gh`, and `pre-commit`
- Adds `.pre-commit-config.yaml` with secret scanning, shellcheck, large file guard, merge conflict detection, trailing whitespace, and custom hooks for Hugo build validation, front matter linting, and static asset reference checking
- Updates CI to run all pre-commit hooks on PRs and gate build/deploy on lint passing
- Removes `snap install dart-sass` (bundled in hugo-extended since 0.114)
- Fixes `new_post.sh` empty-tags guard (was checking array length on a string)
- Fixes `preview.sh`: removes redundant `-t` flag, adds `--buildDrafts`
- Fixes `config.toml`: replaces deprecated `PygmentsCodeFences` with `markup.highlight.codeFences`
- Adds `resources/_gen/` and `.hugo_build.lock` to `.gitignore`
- Adds `CLAUDE.md` with repo guidance

## Test plan

- [ ] Run `mise install && mise x -- pre-commit install` locally
- [ ] Verify `mise x -- pre-commit run --all-files` passes
- [ ] Open a test PR and confirm the `lint` CI job runs and passes
- [ ] Confirm `build`/`deploy` jobs are skipped on the PR (only run on master)
- [ ] After merge, confirm deploy still works end-to-end